### PR TITLE
Update mqtt_arduino_outlets.ino

### DIFF
--- a/code/v2/mqtt_arduino_outlets.ino
+++ b/code/v2/mqtt_arduino_outlets.ino
@@ -107,12 +107,12 @@ void setup()
 {
   mySwitch.enableTransmit(6);
   
-  // SET YOUR PULSE LENGTH
-  mySwitch.setPulseLength(REPLACE_WITH_YOUR_PULSE_LENGTH);
-  
   // SET YOUR PROTOCOL (default is 1, will work for most outlets)
   mySwitch.setProtocol(REPLACE_WITH_YOUR_PROTOCOL);
-  
+
+   // SET YOUR PULSE LENGTH
+  mySwitch.setPulseLength(REPLACE_WITH_YOUR_PULSE_LENGTH);
+ 
   // Set number of transmission repetitions.
   mySwitch.setRepeatTransmit(15);
   Serial.begin(57600);


### PR DESCRIPTION
setPulseLength() must be after setProcotol() otherwise the pulse length value gets reset to default when the protocol is set.

See https://github.com/sui77/rc-switch/issues/88